### PR TITLE
Fix docker-compose.yml code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We recommend that you use our docker image which is preconfigured. Assetgrid use
 
 Example docker-compose.yml file:
 
+```yaml
 version: "3.1"
   services:
     db:
@@ -44,6 +45,7 @@ version: "3.1"
         CONNECTION_STRING: "Server=db;Database=assetgrid;Uid=assetgrid;Pwd=secret"
       ports:
         - 80:8080
+```
 
 Example docker run commands:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Example docker-compose.yml file:
 
 ```yaml
 version: "3.1"
-  services:
+services:
     db:
       image: mariadb:latest
       container_name: mariadb


### PR DESCRIPTION
This PR fixes the docker-compose.yml block in README.md and makes it display correctly.

<img width="864" alt="image" src="https://user-images.githubusercontent.com/18373185/195387863-8de95004-02b9-4aa1-8b1e-70cbc42363c5.png">
